### PR TITLE
Add single string usage 

### DIFF
--- a/changelog
+++ b/changelog
@@ -6,7 +6,7 @@ v.1.0.2 -> v.1.0.3
   - Start
   - Intervals
 
-- Caret: currently added only one extra option, more to come in the feautures
+- Caret: currently added only one extra option, more to come in the future
 
 - Start: added prop to control when the animation should begin when the component is loaded
 
@@ -28,7 +28,7 @@ v.1.0.8 -> v1.0.9
 
 v 1.0.9 -> 1.1.2
 
-- Removed styling to allow users to customize styling themselves. Users reported issues trying to override defualt styles.
+- Removed styling to allow users to customize styling themselves. Users reported issues trying to override default styles.
 
 v 1.1.2 -> 2.0.0
 
@@ -37,3 +37,6 @@ v 1.1.2 -> 2.0.0
   - to: `import {VueWriter} from 'vue-writer'`
 - migrate to typescript and vite.
 - increase node version to 20 (LTS)
+
+v 2.0.0 -> 2.1.0
+- Add single string usage rather than having to always use an array.

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + Vue + TS</title>
+    <title>VueWrite</title>
   </head>
   <body>
     <div id="app"></div>

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Simple usage - registering the component locally
 
 ```js
 <template>
-  <VueWriter :array="['Hello World']" />
+  <VueWriter string="Hello World" />
 </template>
 <script>
 import {VueWriter} from 'vue-writer'
@@ -102,7 +102,7 @@ export default {
 - default: 0
 
 ```html
-<vue-writer :array="['Hello', 'World']" :iterations="'1'"></vue-writer>
+<vue-writer :string="['Hello', 'World']" :iterations="'1'"></vue-writer>
 ```
 
 - By default, this will loop forever unless you specify. This will loop through the array depending on the value you set.
@@ -115,7 +115,7 @@ export default {
 - usage:
 
 ```html
-<vue-writer :array="arr" :typeSpeed="70" />
+<vue-writer :string="arr" :typeSpeed="70" />
 ```
 
 - note: higher the number the slower the typing speed is.
@@ -128,7 +128,7 @@ export default {
 - usage:
 
 ```html
-<vue-writer :array="arr" :eraseSpeed="50" :typeSpeed="100" />
+<vue-writer :string="arr" :eraseSpeed="50" :typeSpeed="100" />
 ```
 
 - note: this prop controls how fast each character is erased in second intervals.
@@ -141,7 +141,7 @@ export default {
 - usage
 
 ```html
-<vue-writer :array="arr" :eraseSpeed="50" :typeSpeed="100" :delay="1000" />
+<vue-writer :string="arr" :eraseSpeed="50" :typeSpeed="100" :delay="1000" />
 ```
 
 - note: 1000 = 1 second
@@ -155,7 +155,7 @@ export default {
 - usage
 
 ```html
-<vue-writer :array="arr" :delay="1000" :intervals="200" />
+<vue-writer :string="arr" :delay="1000" :intervals="200" />
 ```
 
 - note: this prop controls how long the next word in the array will appear after the previous word is fully erased.
@@ -168,7 +168,7 @@ export default {
 - usage
 
 ```html
-<vue-writer :array="arr" :delay="1000" :start="2000" />
+<vue-writer :string="arr" :delay="1000" :start="2000" />
 ```
 
 - note: this prop is used to control when the animation should begin. By default when the component is loaded on the page, the animation will start.
@@ -184,7 +184,7 @@ export default {
 - usage:
 
 ```html
-<vue-writer :array="arr" :caret="underscore" />
+<vue-writer :string="arr" :caret="underscore" />
 ```
 
 - note: this prop changes the style of the caret (more options coming soon)
@@ -194,7 +194,7 @@ export default {
 You can pass child components and nested HTML before this component is loaded. A simple use case is demonstrated below:
 
 ```html
-<vue-writer array='["World"]'>
+<vue-writer string="World">
   <p>Hello</p>
 </vue-writer>
 ```

--- a/readme.md
+++ b/readme.md
@@ -78,17 +78,22 @@ export default {
 
 ### Properties
 
-#### `array`
+#### `string`
 
-- type: Array
+- type: Array | String
 - required: true
 - usage:
 
 ```html
-<vue-writer :array="['adding single string soon']" />
+<!-- You can pass array of strings -->
+<vue-writer :string="['Hello World!', 'VueWriter is awesome!']" />
+<!-- or a single string -->
+<vue-writer string="you can use single string" />
 ```
 
-- note: this prop has to be in an array even if it's a single string.
+#### `array`
+- `deprecated`, will be removed in the next major version.
+- provide the same functionality as `string`
 
 ### `iterations`
 
@@ -262,7 +267,6 @@ Possible Additions and Todo's
 
 This component intends to be minimal and lightweight -- so they're will be a limit to how many additional features will be added in time. Currently, I am looking into adding the following in time:
 
-- Add single string usage rather than having to always use an array
 - Add more customer cursors
 - Add different animation options
 - Add different erasing animations

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,0 +1,67 @@
+<template>
+    <div class="card">
+        <h1>VueWrite Demo</h1>
+
+        <code>
+            &lt;<span>VueWriter :string="['Hello World!', 'VueWriter is an awesome']" </span>/&gt;
+        </code>
+        <VueWriter :string="['Hello World!', 'VueWriter is awesome!']" />
+        
+        <hr />
+        
+        <code>
+            &lt;<span>VueWriter :string="Hello World!" </span>/&gt;
+        </code>
+        <VueWriter string="Hello World!" />
+    </div>
+</template>
+
+<script setup lang='ts'>
+import VueWriter from './vue-writer.vue';
+</script>
+
+<style scoped>
+h1 {
+    font-size: 1.6rem;
+    color: #444;
+}
+code {
+    font-size: 1rem;
+    background-color: #282c34;
+    padding: 1rem;
+    margin-bottom: 0.5rem;
+    display: block;
+    border-radius: 5px;
+    color: white;
+}
+code span {color: #7ec699;}
+hr {margin: 2rem 0;}
+.card {
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+	padding: 1rem;
+	border-radius: 5px;
+    color: #555;
+    max-width: 700px;
+    text-align: center;
+    margin: 5rem auto;
+	line-height: 1.6;
+	font-family:
+		Inter,
+		-apple-system,
+		BlinkMacSystemFont,
+		'Segoe UI',
+		Roboto,
+		Oxygen,
+		Ubuntu,
+		Cantarell,
+		'Fira Sans',
+		'Droid Sans',
+		'Helvetica Neue',
+		sans-serif;
+	font-size: 1.3rem;
+	text-rendering: optimizeLegibility;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+ul li {width: fit-content;}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,14 @@
-import { App } from "vue";
+import { App as IApp, createApp } from "vue";
+import App from "./App.vue"
 import VueWriter from "./vue-writer.vue";
+
+const app = createApp(App);
+
+app.mount('#app');
+
 export { VueWriter };
 export default {
-  install: (app: App) => {
-    // inject a globally available $translate() method
+  install: (app: IApp) => {
     app.component("VueWriter", VueWriter);
   },
 };


### PR DESCRIPTION
### New Feature
Now  you can pass either an array or string via the new prop `string`
```html
<!-- You can pass an array of strings -->
<vue-writer :string="['Hello World!', 'VueWriter is awesome!']" />
<!-- or a single string -->
<vue-writer string="you can use single string" />
```
- The old prop `array` is deprecated and will be removed  in the next major version
-  This PR has backward compatibility, so `array` is still usable.
```html
<!-- You can pass an array of strings -->
<vue-writer :array="['Hello World!', 'VueWriter is awesome!']" />
<!-- or a single string -->
<vue-writer array="you can use single string" />
```
- A Simple demo is added to showcases